### PR TITLE
Clicking on a tracking number now focuses on that number upon redirect

### DIFF
--- a/web_files/scripts/dashboard.js
+++ b/web_files/scripts/dashboard.js
@@ -63,30 +63,30 @@ $(document).ready(function() {
     
   });
 
-  $('.alerted_nums, .active_nums, .delivered_nums').on('click', '.data_ilne_l, .data_line_r', function () {
+  $('.alerted_nums, .active_nums, .delivered_nums').on('click', '.data_line_l, .data_line_r', function () {
     const parent = $(this).parent();
+    const clickedNumber = parent.children('.data_line_l').children('p').text();
+    console.log(clickedNumber);
+    const numList = [];
+    numList.push(clickedNumber);
     if (parent.hasClass('alert_data_line')) {
-      const numList = [];
       for (const parcel of ofd) {
+        if (parcel.TrackNum === clickedNumber) continue;
         numList.push(parcel.TrackNum);
       }
-      const formattedList = numList.join(',');
-      window.location = `/track/num/${formattedList}`;
     } else if (parent.hasClass('active_data_line')) {
-      const numList = [];
       for (const parcel of it) {
+        if (parcel.TrackNum === clickedNumber) continue;
         numList.push(parcel.TrackNum);
       }
-      const formattedList = numList.join(',');
-      window.location = `/track/num/${formattedList}`;
     } else if (parent.hasClass('delivered_data_line')) {
-      const numList = [];
       for (const parcel of dd) {
+        if (parcel.TrackNum === clickedNumber) continue;
         numList.push(parcel.TrackNum);
       }
-      const formattedList = numList.join(',');
-      window.location = `/track/num/${formattedList}`;
     }
+    const formattedList = numList.join(',');
+    window.location = `/track/num/${formattedList}`;
   });
 
   /* Adds a tracking number to the user's stored numbers */


### PR DESCRIPTION
Made it so that when a number is clicked in the dashboard, the clicked-on number is the first, and therefore highlighted number, on the tracking page.